### PR TITLE
Changes to your pvAccess/testCa code

### DIFF
--- a/testCa/Makefile
+++ b/testCa/Makefile
@@ -3,34 +3,45 @@
 TOP = ..
 include $(TOP)/configure/CONFIG
 
+# Need access to caProviderPvt.h
 USR_CPPFLAGS += -I$(TOP)/src/ca
 
-CAPROVIDER_TEST = $(TOP)/testCa
-
-PROD_LIBS += pvAccess pvAccessCA pvData ca Com
+PROD_LIBS += pvAccess pvAccessCA pvData $(EPICS_BASE_IOC_LIBS)
 
 TESTPROD_HOST += testCaProvider
 testCaProvider_SRCS  += testCaProvider.cpp
-testHarness_SRCS += testCaProvider.cpp
+caTestHarness_SRCS += testCaProvider.cpp
 TESTS += testCaProvider
-testHarness_SRCS += pvCaAllTests.c
+ifdef BASE_3_15
+  testCaProvider_SRCS  += testIoc_registerRecordDeviceDriver.cpp
+  REGRDDFLAGS = -l
+else
+  # testCaProvider needs EPICS_HOST_ARCH set in the environment
+  export EPICS_HOST_ARCH
+endif
 
-# testCaProvider needs EPICS_HOST_ARCH set in the environment
-export EPICS_HOST_ARCH
+ifdef BASE_3_15
+  # Embedded OSes need dbUnitTest, Base-3.15 and higher only
 
-# Name the application caTestHarness
-caTestHarness_SRCS = $(testHarness_SRCS)
+  # The test collection is caTestHarness
+  caTestHarness_SRCS += pvCaAllTests.c
 
-# Build for vxWorks
-PROD_vxWorks = caTestHarness
-TESTSPEC_vxWorks = caTestHarness.$(MUNCH_SUFFIX); pvCaAllTests
+  # Build for vxWorks
+  PROD_vxWorks = caTestHarness
+  TESTSPEC_vxWorks = caTestHarness.$(MUNCH_SUFFIX); pvCaAllTests
 
-# Build for RTEMS, with harness code & configuration
-PROD_RTEMS += caTestHarness
-caTestHarness_SRCS_RTEMS += rtemsTestHarness.c
-TESTSPEC_RTEMS = caTestHarness.$(MUNCH_SUFFIX); pvCaAllTests
+  # Build for RTEMS, with harness code & configuration
+  PROD_RTEMS += caTestHarness
+  caTestHarness_SRCS_RTEMS += rtemsTestHarness.c
+  TESTSPEC_RTEMS = caTestHarness.$(MUNCH_SUFFIX); pvCaAllTests
+endif
 
 # Build test scripts for hosts
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 
 include $(TOP)/configure/RULES
+
+ifdef BASE_3_15
+  $(COMMON_DIR)/testIoc.dbd: $(EPICS_BASE)/dbd/softIoc.dbd
+	$(CP) $< $@
+endif

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -709,7 +709,7 @@ void TestIoc::run()
     char * arch;
     arch = getenv("EPICS_HOST_ARCH");
     if(arch==NULL) throw std::runtime_error("TestIoc::run $$EPICS_HOST_ARCH not defined");
-    if(system("$EPICS_BASE/bin/$EPICS_HOST_ARCH/softIoc -d ../testCaProvider.db")!=0) {
+    if(system("$EPICS_BASE/bin/$EPICS_HOST_ARCH/softIoc -x test -d ../testCaProvider.db")!=0) {
         string message(base);
         message += "/bin/";
         message += arch;
@@ -830,7 +830,7 @@ MAIN(testCaProvider)
         client->stopEvents();
 #ifndef USE_DBUNITTEST
         // put to record that makes IOC exit
-        channelName = "DBRexit";
+        channelName = "test:exit";
         client = TestClient::create(channelName,pvRequest);
         if(!client) throw std::runtime_error(channelName + " client null");
         client->put("1");

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -26,6 +26,9 @@
 #include <pv/pvIntrospect.h>
 #include <pv/pvData.h>
 
+// DEBUG must be 0 to run under the automated test harness
+#define DEBUG 0
+
 using namespace epics::pvData;
 using namespace epics::pvAccess;
 using namespace epics::pvAccess::ca;
@@ -584,7 +587,7 @@ void TestClient::getDone(
    testOk(pvStructure->getSubField("value")!=NULL,"value not null");
    testOk(pvStructure->getSubField("timeStamp")!=NULL,"timeStamp not null");
    testOk(pvStructure->getSubField("alarm")!=NULL,"alarm not null");
-   std::cout << testChannel->getChannelName() + " TestClient::getDone"
+   if (DEBUG) std::cout << testChannel->getChannelName() + " TestClient::getDone"
              << " bitSet " << *bitSet
              << " pvStructure\n" << pvStructure << "\n";
    waitForGet.signal();
@@ -599,35 +602,38 @@ void TestClient::monitorEvent(
         PVStructure::shared_pointer const & pvStructure,
         BitSet::shared_pointer const & bitSet)
 {
-   std::cout << testChannel->getChannelName() + " TestClient::monitorEvent"
+   if (DEBUG) std::cout << testChannel->getChannelName() + " TestClient::monitorEvent"
              << " bitSet " << *bitSet
              << " pvStructure\n" << pvStructure << "\n";
 }
 
 void TestClient::get()
 {
-cout << "TestClient::get() calling get\n";
+    testDiag("TestClient::get %s",
+        testChannel->getChannelName().c_str());
     testChannelGet->get();
-cout << "TestClient::get() calling waitGet\n";
+   if (DEBUG) cout << "TestClient::get() calling waitGet\n";
     waitGet(5.0);
 }
 
 void TestClient::waitGet(double timeout)
 {
-    if(waitForGet.wait(timeout)) return;
-    throw std::runtime_error(testChannel->getChannelName() + " TestClient::waitGet failed ");
+    testOk(waitForGet.wait(timeout),
+        "waitGet(%s) succeeded", testChannel->getChannelName().c_str());
 }
 
 void TestClient::put(string const & value)
 {
+    testDiag("TestClient::put %s := %s",
+        testChannel->getChannelName().c_str(), value.c_str());
     testChannelPut->put(value);
     waitPut(5.0);
 }
 
 void TestClient::waitPut(double timeout)
 {
-    if(waitForPut.wait(timeout)) return;
-    throw std::runtime_error(testChannel->getChannelName() + " TestClient::waitPut failed ");
+    testOk(waitForPut.wait(timeout),
+        "waitPut(%s) succeeded", testChannel->getChannelName().c_str());
 }
 
 void TestClient::stopEvents()
@@ -686,7 +692,7 @@ MAIN(testCaProvider)
 
     TestIocPtr testIoc(new TestIoc());
     testIoc->start();  
-    testPlan(56);
+    testPlan(84);
     testDiag("===Test caProvider===");
     CAClientFactory::start();
     ChannelProviderRegistry::shared_pointer reg(ChannelProviderRegistry::clients());

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -709,6 +709,8 @@ void TestIoc::run()
     char * arch;
     arch = getenv("EPICS_HOST_ARCH");
     if(arch==NULL) throw std::runtime_error("TestIoc::run $$EPICS_HOST_ARCH not defined");
+    setenv("EPICS_CA_ADDR_LIST", "localhost", 1);
+    setenv("EPICS_CA_AUTO_ADDR_LIST", "NO", 1);
     if(system("$EPICS_BASE/bin/$EPICS_HOST_ARCH/softIoc -x test -d ../testCaProvider.db")!=0) {
         string message(base);
         message += "/bin/";

--- a/testCa/testCaProvider.db
+++ b/testCa/testCaProvider.db
@@ -131,12 +131,6 @@ record(stringin,"DBRstringin") {
 
 record(bo,"DBRbinaryout") {
     field(DESC, "bo")
-    field(OUT, "DBRbi.VAL PP NMS")
-    field(ZNAM,"zero")
-    field(ONAM,"one")
-}
-record(bi,"DBRbinaryin") {
-    field(DESC, "bi")
     field(ZNAM,"zero")
     field(ONAM,"one")
 }

--- a/testCa/testCaProvider.db
+++ b/testCa/testCaProvider.db
@@ -39,12 +39,6 @@ record(calc, "DBRcalcin")
     field(LLSV, "MAJOR")
 }
 
-record(sub, "DBRexit")
-{
-    field(DESC, "exit")
-    field(SNAM, "exit")
-}
-
 record(longin,"DBRlongin") {
     field(DESC, "longin")
     field(EGU, "volts")


### PR DESCRIPTION
Hi Marty,

This is a Pull Request into *your* mrkraimer/pvAccessCPP master branch containing changes that make testCaProvider.cpp use the dbUnitTest API wherever possible. When built against Base-3.14 it will not attempt to compile the tests for RTEMS or VxWorks, and for the workstation OSs (Linux, MacOS & Windows) it will run the softIoc as a separate process using `system()` as your version does.

I have made a number of clean-ups, and introduced a DEBUG flag which suppresses the got value printing (the multi-line output from printing a BitSet or PVStructure is not compatible with the test harness, so you should only set DEBUG to 1 temporarily for debugging purposes and reset it back to 0 before committing any changes).

I will admit I haven't actually tested this against anything other than Base-7.0 but I have checked both the internal and external IOC configurations. If there are any failures against older versions of Base or against Windows I will fix them when Travis or Jenkins discover the problems.

Remember, this is a PR targeted at your development branch on GitHub; you have to merge it if you're Ok with my changes, which will add them to your branch and to your PR for the official repo; pressing the Merge button here will not add anything to the official repo.

Let me know if you have any questions or objections.

- Andrew
