### PR TITLE
More updates & fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ testApp_DEPEND_DIRS = src
 
 
 DIRS += testCa
-testCa_DEPEND_DIRS = src
+testCa_DEPEND_DIRS = src src/ca
 
 
 DIRS += examples

--- a/testCa/Makefile
+++ b/testCa/Makefile
@@ -12,7 +12,7 @@ TESTPROD_HOST += testCaProvider
 testCaProvider_SRCS  += testCaProvider.cpp
 caTestHarness_SRCS += testCaProvider.cpp
 TESTS += testCaProvider
-ifdef BASE_3_15
+ifdef BASE_3_16
   testCaProvider_SRCS  += testIoc_registerRecordDeviceDriver.cpp
   REGRDDFLAGS = -l
 else
@@ -20,8 +20,8 @@ else
   export EPICS_HOST_ARCH
 endif
 
-ifdef BASE_3_15
-  # Embedded OSes need dbUnitTest, Base-3.15 and higher only
+ifdef BASE_3_16
+  # Embedded OSes need Base-3.16.2 or higher to pass tests
 
   # The test collection is caTestHarness
   caTestHarness_SRCS += pvCaAllTests.c
@@ -41,7 +41,7 @@ TESTSCRIPTS_HOST += $(TESTS:%=%.t)
 
 include $(TOP)/configure/RULES
 
-ifdef BASE_3_15
+ifdef BASE_3_16
   $(COMMON_DIR)/testIoc.dbd: $(EPICS_BASE)/dbd/softIoc.dbd
 	$(CP) $< $@
 endif

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -15,7 +15,8 @@
 #include <testMain.h>
 #include <epicsVersion.h>
 
-#if defined(VERSION_INT) && EPICS_VERSION_INT >= VERSION_INT(3,15,0,1)
+#ifdef EPICS_VERSION_INT
+  #if EPICS_VERSION_INT >= VERSION_INT(3,15,0,1)
     #define USE_DBUNITTEST
     // USE_TYPED_RSET prevents deprecation warnings
     #define USE_TYPED_RSET
@@ -25,8 +26,11 @@
     #include <dbUnitTest.h>
 
     extern "C" int testIoc_registerRecordDeviceDriver(struct dbBase *pbase);
-#else
-    #define EXIT_TESTS 1
+  #endif
+#endif
+
+#ifndef EXIT_TESTS
+  #define EXIT_TESTS 1
 #endif
 
 #include <pv/thread.h>

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -673,6 +673,8 @@ public:
 private:
 #ifndef USE_DBUNITTEST
     std::auto_ptr<epicsThread> thread;
+    const char *base;
+    const char *arch;
 #endif
 };
 
@@ -692,7 +694,16 @@ void TestIoc::start()
     testIocInitOk();
     eltc(1);
 #else
-     thread =  std::auto_ptr<epicsThread>(new epicsThread(
+    base = getenv("EPICS_BASE");
+    if (!base)
+        testAbort("Environment variable $EPICS_BASE not defined");
+    arch = getenv("EPICS_HOST_ARCH");
+    if (!arch)
+        testAbort("Environment variable $EPICS_HOST_ARCH not defined");
+    setenv("EPICS_CA_ADDR_LIST", "localhost", 1);
+    setenv("EPICS_CA_AUTO_ADDR_LIST", "NO", 1);
+
+    thread =  std::auto_ptr<epicsThread>(new epicsThread(
         *this,
         "testIoc",
         epicsThreadGetStackSize(epicsThreadStackSmall),
@@ -708,14 +719,6 @@ void TestIoc::run()
     // tests with an embedded IOC fail with a Base before 3.16.2.
     // This version only works on workstation targets, it runs the
     // softIoc from Base as a separate process, using system().
-    char * base;
-    base = getenv("EPICS_BASE");
-    if(base==NULL) throw std::runtime_error("TestIoc::run $EPICS_BASE not defined");
-    char * arch;
-    arch = getenv("EPICS_HOST_ARCH");
-    if(arch==NULL) throw std::runtime_error("TestIoc::run $$EPICS_HOST_ARCH not defined");
-    setenv("EPICS_CA_ADDR_LIST", "localhost", 1);
-    setenv("EPICS_CA_AUTO_ADDR_LIST", "NO", 1);
     if(system("$EPICS_BASE/bin/$EPICS_HOST_ARCH/softIoc -x test -d ../testCaProvider.db")!=0) {
         string message(base);
         message += "/bin/";

--- a/testCa/testCaProvider.cpp
+++ b/testCa/testCaProvider.cpp
@@ -16,7 +16,7 @@
 #include <epicsVersion.h>
 
 #ifdef EPICS_VERSION_INT
-  #if EPICS_VERSION_INT >= VERSION_INT(3,15,0,1)
+  #if EPICS_VERSION_INT >= VERSION_INT(3,16,2,0)
     #define USE_DBUNITTEST
     // USE_TYPED_RSET prevents deprecation warnings
     #define USE_TYPED_RSET
@@ -704,8 +704,9 @@ void TestIoc::start()
 void TestIoc::run()
 {
 #ifndef USE_DBUNITTEST
-    // Base-3.14 doesn't provide the dbUnitTest APIs.
-    // This code only works on workstation targets, it runs the
+    // Base-3.14 doesn't provide the dbUnitTest APIs, and the CA
+    // tests with an embedded IOC fail with a Base before 3.16.2.
+    // This version only works on workstation targets, it runs the
     // softIoc from Base as a separate process, using system().
     char * base;
     base = getenv("EPICS_BASE");


### PR DESCRIPTION
Hi Marty,

Yes, some change committed to the Base-3.16 branch since the 3.16.1 release seems to be needed for the integrated IOC to work properly (I can guess which one, but I haven't bothered to check). The Base-3.15 branch doesn't work at all with the integrated IOC, not sure why. I have modified my version checks to use the external softIoc for any Base before 3.16.2, which should be coming out fairly soon. I also fixed a parallel build dependency issue, a problem with my version number tests for 3.14, and I replaced some more `throw` operations with calls to `testAbort()`.

As before, this is a PR into your development branch.

- Andrew
